### PR TITLE
fix cyclic dependency with outer-rim

### DIFF
--- a/info.json
+++ b/info.json
@@ -25,7 +25,6 @@
     "? metal-and-stars",
     "? naufulglebunusilo",
     "? Nexus",
-    "? outer-rim",
     "? Paracelsin",
     "? planet-akularis",
     "? planet-arrakis",


### PR DESCRIPTION
The outer rim dependency created a cycle, crashing the game. Since it seems like the "load order ignoring" dependencies are not optional (https://lua-api.factorio.com/latest/auxiliary/mod-structure.html), removing the dependency would be the only viable fix.